### PR TITLE
Fix README conflict and color duplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-<<<<<<< HEAD
-# LowkeyframesPortfolio
+# lowkeyframes-portfolio
 
 This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 17.1.2.
 
@@ -26,6 +25,4 @@ Run `ng e2e` to execute the end-to-end tests via a platform of your choice. To u
 ## Further help
 
 To get more help on the Angular CLI use `ng help` or go check out the [Angular CLI Overview and Command Reference](https://angular.io/cli) page.
-=======
-# lowkeyframes-portfolio
->>>>>>> 202ce7c3db091c08f55c132af949dc4900182e53
+

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,7 +8,7 @@ module.exports = {
       colors: {
         dark: '#0D0D0D',
         neon: '#00FF88',
-        mint: '#1DB954',
+        mintDark: '#1DB954',
         surface: '#1A1A1A',
         light: '#EAEAEA',
         border: '#333333',


### PR DESCRIPTION
## Summary
- clean up merge conflict markers in README
- rename duplicate `mint` color in Tailwind config

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find module '@angular/core', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684c4bf85a008331987e5af522894331