### PR TITLE
Fix page title in index.html

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>LowkeyframesPortfolio</title>
+  <title>LowKey Frames Portfolio</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">


### PR DESCRIPTION
## Summary
- correct the HTML title to display "LowKey Frames Portfolio"

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c4f6b8e3483319cc71794340b572a