### PR TITLE
Add page titles and meta descriptions

### DIFF
--- a/src/app/pages/contact/contact.component.ts
+++ b/src/app/pages/contact/contact.component.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { Title, Meta } from '@angular/platform-browser';
 import { FormsModule } from '@angular/forms';
 import { trigger, state, style, animate, transition } from '@angular/animations';
 import { CommonModule } from '@angular/common';
@@ -16,10 +17,17 @@ import { CommonModule } from '@angular/common';
     ]),
   ],
 })
-export class ContactComponent {
+export class ContactComponent implements OnInit {
   name = '';
   email = '';
   message = '';
+
+  constructor(private titleService: Title, private meta: Meta) {}
+
+  ngOnInit() {
+    this.titleService.setTitle('Contact - Lowkeyframes');
+    this.meta.updateTag({ name: 'description', content: 'Send a message to connect with Lowkeyframes.' });
+  }
 
   hoverState = 'normal';
 

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { Title, Meta } from '@angular/platform-browser';
 import { RouterModule } from '@angular/router';
 
 @Component({
@@ -8,4 +9,11 @@ import { RouterModule } from '@angular/router';
   templateUrl: './home.component.html',
   styleUrls: ['./home.component.scss'],
 })
-export class HomeComponent {}
+export class HomeComponent implements OnInit {
+  constructor(private titleService: Title, private meta: Meta) {}
+
+  ngOnInit() {
+    this.titleService.setTitle('Home - Lowkeyframes');
+    this.meta.updateTag({ name: 'description', content: 'Welcome to the Lowkeyframes portfolio home page.' });
+  }
+}

--- a/src/app/pages/photography/photography.component.ts
+++ b/src/app/pages/photography/photography.component.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { Title, Meta } from '@angular/platform-browser';
 import { ALBUMS, Album } from '../../data/albums';
 import { RouterModule } from '@angular/router';
 import { CommonModule } from '@angular/common';
@@ -9,6 +10,13 @@ import { CommonModule } from '@angular/common';
   imports: [RouterModule, CommonModule],
   templateUrl: './photography.component.html',
 })
-export class PhotographyComponent {
+export class PhotographyComponent implements OnInit {
   albums: Album[] = ALBUMS;
+
+  constructor(private titleService: Title, private meta: Meta) {}
+
+  ngOnInit() {
+    this.titleService.setTitle('Photography - Lowkeyframes');
+    this.meta.updateTag({ name: 'description', content: 'Explore photography albums showcasing diverse stories and portraits.' });
+  }
 }

--- a/src/app/pages/professional/professional.component.ts
+++ b/src/app/pages/professional/professional.component.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { Title, Meta } from '@angular/platform-browser';
 import { Project, PROJECTS } from '../../data/projects';
 import { CommonModule } from '@angular/common'; // Import CommonModule for Angular directives
 import { ProjectModalComponent } from '../../components/project-modal/project-modal.component';
@@ -10,9 +11,16 @@ import { ProjectModalComponent } from '../../components/project-modal/project-mo
   templateUrl: './professional.component.html',
   styleUrls: ['./professional.component.scss']
 })
-export class ProfessionalComponent {
+export class ProfessionalComponent implements OnInit {
   projects: Project[] = PROJECTS;
   selectedProject: Project | null = null;
+
+  constructor(private titleService: Title, private meta: Meta) {}
+
+  ngOnInit() {
+    this.titleService.setTitle('Professional Work - Lowkeyframes');
+    this.meta.updateTag({ name: 'description', content: 'Browse professional projects and collaborations.' });
+  }
 
   openProjectModal(project: Project) {
     this.selectedProject = project;


### PR DESCRIPTION
## Summary
- add `Title` and `Meta` services to page components
- set a page title and description on init for SEO

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68508261a980833199894783e10249d6