### PR TITLE
Enhance portfolio pages

### DIFF
--- a/src/app/pages/album-viewer/album-viewer.component.html
+++ b/src/app/pages/album-viewer/album-viewer.component.html
@@ -9,7 +9,7 @@
   <h2 class="text-2xl sm:text-3xl font-bold text-green-400 mb-4 animate-fade-in-up">{{ album.title }}</h2>
   <swiper-container
     pagination="true"
-    [navigation]="album?.images?.length > 1"
+    [navigation]="album && album.images && album.images.length > 1"
     loop="true"
     slides-per-view="1"
     class="w-full max-w-full sm:max-w-5xl h-[65vh] sm:h-[80vh] rounded-none sm:rounded-lg animate-fade-in-up"

--- a/src/app/pages/album-viewer/album-viewer.component.html
+++ b/src/app/pages/album-viewer/album-viewer.component.html
@@ -9,7 +9,7 @@
   <h2 class="text-2xl sm:text-3xl font-bold text-green-400 mb-4 animate-fade-in-up">{{ album.title }}</h2>
   <swiper-container
     pagination="true"
-    navigation="true"
+    [navigation]="album?.images.length > 1"
     loop="true"
     slides-per-view="1"
     class="w-full max-w-full sm:max-w-5xl h-[65vh] sm:h-[80vh] rounded-none sm:rounded-lg animate-fade-in-up"

--- a/src/app/pages/album-viewer/album-viewer.component.html
+++ b/src/app/pages/album-viewer/album-viewer.component.html
@@ -1,6 +1,6 @@
 <button
   (click)="goBack()"
-  class="fixed top-2 left-2 sm:top-4 sm:left-4 z-50 bg-green-600 hover:bg-green-700 text-black px-3 sm:px-4 py-2 rounded shadow"
+  class="fixed bottom-4 left-4 sm:bottom-8 sm:left-8 z-50 bg-green-600 hover:bg-green-700 text-black px-3 sm:px-4 py-2 rounded shadow"
 >
   Back
 </button>

--- a/src/app/pages/album-viewer/album-viewer.component.html
+++ b/src/app/pages/album-viewer/album-viewer.component.html
@@ -9,7 +9,7 @@
   <h2 class="text-2xl sm:text-3xl font-bold text-green-400 mb-4 animate-fade-in-up">{{ album.title }}</h2>
   <swiper-container
     pagination="true"
-    [navigation]="album?.images.length > 1"
+    [navigation]="album?.images?.length > 1"
     loop="true"
     slides-per-view="1"
     class="w-full max-w-full sm:max-w-5xl h-[65vh] sm:h-[80vh] rounded-none sm:rounded-lg animate-fade-in-up"

--- a/src/app/pages/album-viewer/album-viewer.component.html
+++ b/src/app/pages/album-viewer/album-viewer.component.html
@@ -5,13 +5,14 @@
   Back
 </button>
 
-<div *ngIf="album" class="min-h-screen bg-black flex items-center justify-center p-4">
+<div *ngIf="album" class="min-h-screen bg-black flex flex-col items-center justify-center p-4">
+  <h2 class="text-2xl sm:text-3xl font-bold text-green-400 mb-4 animate-fade-in-up">{{ album.title }}</h2>
   <swiper-container
     pagination="true"
     navigation="true"
     loop="true"
     slides-per-view="1"
-    class="w-full max-w-full sm:max-w-5xl h-[65vh] sm:h-[80vh] rounded-none sm:rounded-lg"
+    class="w-full max-w-full sm:max-w-5xl h-[65vh] sm:h-[80vh] rounded-none sm:rounded-lg animate-fade-in-up"
   >
     <swiper-slide *ngFor="let img of album.images">
       <img

--- a/src/app/pages/album-viewer/album-viewer.component.ts
+++ b/src/app/pages/album-viewer/album-viewer.component.ts
@@ -7,6 +7,7 @@ import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { AwsS3Service } from '../../services/aws-s3.service';
 import { environment } from '../../../environments/environment';
+import { Title, Meta } from '@angular/platform-browser';
 
 @Component({
   selector: 'app-album-viewer',
@@ -23,7 +24,9 @@ export class AlbumViewerComponent implements OnDestroy {
   constructor(
     private route: ActivatedRoute,
     private router: Router,
-    private s3: AwsS3Service
+    private s3: AwsS3Service,
+    private titleService: Title,
+    private meta: Meta
   ) {
     this.paramSub = this.route.params.subscribe(async params => {
       const id = params['id'];
@@ -32,6 +35,8 @@ export class AlbumViewerComponent implements OnDestroy {
         this.router.navigate(['/photography']);
         return;
       }
+      this.titleService.setTitle(`${this.album.title} - Lowkeyframes`);
+      this.meta.updateTag({ name: 'description', content: `Viewing the ${this.album.title} album.` });
       try {
         const bucket = environment.aws.bucket;
         const images = await this.s3.listObjects(bucket, `${id}/`);

--- a/src/app/pages/photography/photography.component.html
+++ b/src/app/pages/photography/photography.component.html
@@ -26,7 +26,7 @@
       </div>
     </a>
   </div>
-  <div class="sticky bottom-4 mt-4 flex justify-center pointer-events-none">
+  <div class="sticky bottom-4 mt-4 flex justify-center pointer-events-none sm:hidden">
     <span class="animate-bounce text-3xl text-emerald">↓</span>
   </div>
 </section>

--- a/src/app/pages/photography/photography.component.html
+++ b/src/app/pages/photography/photography.component.html
@@ -26,4 +26,7 @@
       </div>
     </a>
   </div>
+  <div class="sticky bottom-4 mt-4 flex justify-center pointer-events-none">
+    <span class="animate-bounce text-3xl text-emerald">↓</span>
+  </div>
 </section>

--- a/src/app/pages/photography/photography.component.html
+++ b/src/app/pages/photography/photography.component.html
@@ -9,9 +9,19 @@
       [routerLink]="['/album', album.id]"
       class="group rounded-xl overflow-hidden bg-mint shadow-lg hover:shadow-xl transition-transform transform hover:scale-[1.02] border border-transparent hover:border-green-500"
     >
-      <img [src]="album.cover" [alt]="album.title" class="w-full h-60 object-cover group-hover:scale-105 transition-transform duration-300" />
+      <div class="relative">
+        <img
+          [src]="album.cover"
+          [alt]="album.title"
+          class="w-full h-60 object-cover transition-transform duration-300 group-hover:scale-105"
+        />
+        <div
+          class="absolute inset-0 bg-black/50 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity"
+        >
+          <h3 class="text-xl font-semibold text-white">{{ album.title }}</h3>
+        </div>
+      </div>
       <div class="p-4">
-        <h3 class="text-xl font-semibold text-emerald">{{ album.title }}</h3>
         <p class="text-charcoal text-sm">{{ album.description }}</p>
       </div>
     </a>


### PR DESCRIPTION
## Summary
- overlay album titles on photography page
- show album titles in viewer with fade-in effect
- update album viewer metadata

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68581d099d8c8331aed2f6ca05e68cb5