### PR TITLE
Improve about page dynamics

### DIFF
--- a/src/app/pages/about/about.component.html
+++ b/src/app/pages/about/about.component.html
@@ -5,15 +5,17 @@
     class="mx-auto mb-6 w-32 h-32 rounded-full object-cover shadow-md sticky top-0 z-10 sm:w-48 sm:h-48 sm:float-right sm:mb-4 sm:ml-6 sm:static"
   />
   <h2 class="text-4xl font-extrabold mb-6 text-center text-emerald">About Me</h2>
-  <p class="mb-4 typing">Hey, I&rsquo;m Lokesh &ndash; but most people know me through the moments I freeze in time.</p>
-  <p class="mb-4 animate-fade-in-up">By profession, I&rsquo;m a web architect &mdash; building sleek, smart digital spaces. But my heart? It belongs to the camera.</p>
+  <p class="mb-4 max-w-prose">
+    <span class="typing" style="--chars:79">Hey, I&rsquo;m Lokesh &ndash; but most people know me through the moments I freeze in time.</span>
+  </p>
+  <p class="mb-4 animate-fade-in-up opacity-0" style="animation-delay:4s">By profession, I&rsquo;m a web architect &mdash; building sleek, smart digital spaces. But my heart? It belongs to the camera.</p>
 
-  <p class="mb-4 animate-fade-in-up">Through lowkey.frames, I capture everyday magic. Through twinedheartsbyloki, I document love, laughter, and life&rsquo;s quiet beauty &mdash; especially for families and little ones.</p>
+  <p class="mb-4 animate-fade-in-up opacity-0" style="animation-delay:4.5s">Through lowkey.frames, I capture everyday magic. Through twinedheartsbyloki, I document love, laughter, and life&rsquo;s quiet beauty &mdash; especially for families and little ones.</p>
 
-  <p class="mb-4 animate-fade-in-up">I believe the best stories are told in glances, giggles, and golden-hour light. Whether it&rsquo;s a line of code or a line of sight, I see everything as a chance to create something meaningful.</p>
+  <p class="mb-4 animate-fade-in-up opacity-0" style="animation-delay:5s">I believe the best stories are told in glances, giggles, and golden-hour light. Whether it&rsquo;s a line of code or a line of sight, I see everything as a chance to create something meaningful.</p>
 
-  <p class="mb-8 animate-fade-in-up">Thanks for being here &mdash; I&rsquo;d love to show you the world through my lens.</p>
-  <div class="text-center">
+  <p class="mb-8 animate-fade-in-up opacity-0" style="animation-delay:5.5s">Thanks for being here &mdash; I&rsquo;d love to show you the world through my lens.</p>
+  <div class="text-center opacity-0 animate-fade-in-up" style="animation-delay:6s">
     <a
       routerLink="/contact"
       class="inline-block bg-neon text-charcoal font-semibold py-3 px-6 rounded-md shadow-neon-green hover:brightness-110 transform hover:-translate-y-1 transition animate-bounce"

--- a/src/app/pages/about/about.component.html
+++ b/src/app/pages/about/about.component.html
@@ -1,18 +1,24 @@
-<section class="min-h-screen bg-lavender text-charcoal px-4 py-12 text-center">
-  <h2 class="text-4xl font-extrabold mb-6 text-emerald">About Me</h2>
-  <p class="mb-4">Hey, I&rsquo;m Lokesh &ndash; but most people know me through the moments I freeze in time.</p>
-  <p class="mb-4">By profession, I&rsquo;m a web architect &mdash; building sleek, smart digital spaces. But my heart? It belongs to the camera.</p>
+<section class="min-h-screen bg-lavender text-charcoal px-4 py-12">
+  <img
+    src="/assets/photos/photo1.jpg"
+    alt="Lokesh smiling while working"
+    class="mx-auto mb-6 w-32 h-32 rounded-full object-cover shadow-md sticky top-0 z-10 sm:w-48 sm:h-48 sm:float-right sm:mb-4 sm:ml-6 sm:static"
+  />
+  <h2 class="text-4xl font-extrabold mb-6 text-center text-emerald">About Me</h2>
+  <p class="mb-4 typing">Hey, I&rsquo;m Lokesh &ndash; but most people know me through the moments I freeze in time.</p>
+  <p class="mb-4 animate-fade-in-up">By profession, I&rsquo;m a web architect &mdash; building sleek, smart digital spaces. But my heart? It belongs to the camera.</p>
 
-  <p class="mb-4">Through lowkey.frames, I capture everyday magic. Through twinedheartsbyloki, I document love, laughter, and life&rsquo;s quiet beauty &mdash; especially for families and little ones.</p>
+  <p class="mb-4 animate-fade-in-up">Through lowkey.frames, I capture everyday magic. Through twinedheartsbyloki, I document love, laughter, and life&rsquo;s quiet beauty &mdash; especially for families and little ones.</p>
 
-  <p class="mb-4">I believe the best stories are told in glances, giggles, and golden-hour light. Whether it&rsquo;s a line of code or a line of sight, I see everything as a chance to create something meaningful.</p>
+  <p class="mb-4 animate-fade-in-up">I believe the best stories are told in glances, giggles, and golden-hour light. Whether it&rsquo;s a line of code or a line of sight, I see everything as a chance to create something meaningful.</p>
 
-  <p class="mb-8">Thanks for being here &mdash; I&rsquo;d love to show you the world through my lens.</p>
-  <img src="/assets/photos/photo1.jpg" alt="Lokesh smiling while working" class="mx-auto mb-8 rounded-lg shadow-md w-64 h-64 object-cover" />
-  <a
-    routerLink="/contact"
-    class="inline-block bg-neon text-charcoal font-semibold py-3 px-6 rounded-md shadow-neon-green hover:brightness-110 transform hover:-translate-y-1 transition"
-  >
-    Let's connect!
-  </a>
+  <p class="mb-8 animate-fade-in-up">Thanks for being here &mdash; I&rsquo;d love to show you the world through my lens.</p>
+  <div class="text-center">
+    <a
+      routerLink="/contact"
+      class="inline-block bg-neon text-charcoal font-semibold py-3 px-6 rounded-md shadow-neon-green hover:brightness-110 transform hover:-translate-y-1 transition animate-bounce"
+    >
+      Let's connect!
+    </a>
+  </div>
 </section>

--- a/src/app/pages/about/about.component.scss
+++ b/src/app/pages/about/about.component.scss
@@ -1,0 +1,23 @@
+/* Typing animation for intro paragraph */
+.typing {
+  overflow: hidden;
+  white-space: nowrap;
+  border-right: 2px solid currentColor;
+  animation: typing 3s steps(40, end), blink 0.75s step-end infinite;
+}
+
+@keyframes typing {
+  from {
+    width: 0;
+  }
+  to {
+    width: 100%;
+  }
+}
+
+@keyframes blink {
+  50% {
+    border-color: transparent;
+  }
+}
+

--- a/src/app/pages/about/about.component.scss
+++ b/src/app/pages/about/about.component.scss
@@ -1,9 +1,12 @@
 /* Typing animation for intro paragraph */
 .typing {
+  display: block;
   overflow: hidden;
-  white-space: nowrap;
+  max-width: 65ch;
+  white-space: normal;
   border-right: 2px solid currentColor;
-  animation: typing 3s steps(40, end), blink 0.75s step-end infinite;
+  animation: typing var(--typing-duration, 4s) steps(var(--chars), end) forwards,
+    blink 0.75s step-end infinite;
 }
 
 @keyframes typing {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -29,8 +29,8 @@ module.exports = {
         'neon-green': '0 0 10px #4ADE80',
       },
         animation: {
-          'fade-in': 'fadeIn 0.6s ease-out',
-          'fade-in-up': 'fadeInUp 1s ease-out',
+          'fade-in': 'fadeIn 0.6s ease-out forwards',
+          'fade-in-up': 'fadeInUp 1s ease-out forwards',
         },
       keyframes: {
         fadeIn: {


### PR DESCRIPTION
## Summary
- add sticky hero image on the about page
- animate intro text with typing and fade effects
- bounce the contact button for extra fun

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68602516b8e083318039eccadb1395b3