### PR TITLE
Update README with Angular CLI test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,15 @@ Run `ng build` to build the project. The build artifacts will be stored in the `
 
 ## Running unit tests
 
-Run `ng test` to execute the unit tests via [Karma](https://karma-runner.github.io).
+Before running the tests, make sure the Angular CLI is available. Install it globally with:
+
+```bash
+npm install -g @angular/cli
+```
+
+Alternatively, you can use `npx ng` without a global install.
+
+Run `npm test` to execute the unit tests via [Karma](https://karma-runner.github.io).
 
 ## AWS S3 Configuration
 


### PR DESCRIPTION
## Summary
- show how to install Angular CLI before running tests

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862f1015abc83318b5893479c167985