### PR TITLE
Fix about page typing layout

### DIFF
--- a/src/app/pages/about/about.component.html
+++ b/src/app/pages/about/about.component.html
@@ -6,7 +6,13 @@
   />
   <h2 class="text-4xl font-extrabold mb-6 text-center text-emerald">About Me</h2>
   <p class="mb-4 max-w-prose">
-    <span class="typing" style="--chars:79">Hey, I&rsquo;m Lokesh &ndash; but most people know me through the moments I freeze in time.</span>
+    <span
+      class="typing"
+      style="--chars:79"
+      (animationend)="typingDone = true"
+      [class.done]="typingDone"
+      >Hey, I&rsquo;m Lokesh &ndash; but most people know me through the moments I freeze in time.</span
+    >
   </p>
   <p class="mb-4 animate-fade-in-up opacity-0" style="animation-delay:4s">By profession, I&rsquo;m a web architect &mdash; building sleek, smart digital spaces. But my heart? It belongs to the camera.</p>
 
@@ -24,3 +30,4 @@
     </a>
   </div>
 </section>
+

--- a/src/app/pages/about/about.component.scss
+++ b/src/app/pages/about/about.component.scss
@@ -4,10 +4,22 @@
   overflow: hidden;
   max-width: 65ch;
   white-space: normal;
-  border-right: 2px solid currentColor;
   clip-path: inset(0 0 0 100%);
-  animation: reveal var(--typing-duration, 4s) steps(var(--chars), end) forwards,
-    blink 0.75s step-end infinite;
+  animation: reveal var(--typing-duration, 4s) steps(var(--chars), end) forwards;
+}
+
+.typing::after {
+  content: '';
+  display: inline-block;
+  width: 2px;
+  height: 1em;
+  margin-left: 2px;
+  background-color: currentColor;
+  animation: blink 0.75s step-end infinite;
+}
+
+.typing.done::after {
+  display: none;
 }
 
 @keyframes reveal {
@@ -18,7 +30,7 @@
 
 @keyframes blink {
   50% {
-    border-color: transparent;
+    opacity: 0;
   }
 }
 

--- a/src/app/pages/about/about.component.scss
+++ b/src/app/pages/about/about.component.scss
@@ -5,16 +5,14 @@
   max-width: 65ch;
   white-space: normal;
   border-right: 2px solid currentColor;
-  animation: typing var(--typing-duration, 4s) steps(var(--chars), end) forwards,
+  clip-path: inset(0 0 0 100%);
+  animation: reveal var(--typing-duration, 4s) steps(var(--chars), end) forwards,
     blink 0.75s step-end infinite;
 }
 
-@keyframes typing {
-  from {
-    width: 0;
-  }
+@keyframes reveal {
   to {
-    width: 100%;
+    clip-path: inset(0 0 0 0);
   }
 }
 

--- a/src/app/pages/about/about.component.ts
+++ b/src/app/pages/about/about.component.ts
@@ -10,6 +10,7 @@ import { RouterModule } from '@angular/router';
   styleUrls: ['./about.component.scss']
 })
 export class AboutComponent implements OnInit {
+  typingDone = false;
   constructor(private titleService: Title, private meta: Meta) {}
 
   ngOnInit() {
@@ -17,3 +18,4 @@ export class AboutComponent implements OnInit {
     this.meta.updateTag({ name: 'description', content: 'Learn more about Lokesh and the philosophy behind Lowkeyframes.' });
   }
 }
+


### PR DESCRIPTION
## Summary
- fix typewriter animation layout on About page using clip-path

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863e79412c483318b541e9cb3a29b54