### PR TITLE
Add masonry layout to album pages

### DIFF
--- a/src/app/pages/album-viewer/album-viewer.component.html
+++ b/src/app/pages/album-viewer/album-viewer.component.html
@@ -5,23 +5,17 @@
   Back
 </button>
 
-<div *ngIf="album" class="min-h-screen bg-black flex flex-col items-center justify-center p-4">
-  <h2 class="text-2xl sm:text-3xl font-bold text-green-400 mb-4 animate-fade-in-up">{{ album.title }}</h2>
-  <swiper-container
-    pagination="true"
-    [navigation]="album && album.images && album.images.length > 1"
-    loop="true"
-    slides-per-view="1"
-    class="w-full max-w-full sm:max-w-5xl h-[65vh] sm:h-[80vh] rounded-none sm:rounded-lg animate-fade-in-up"
-  >
-    <swiper-slide *ngFor="let img of album.images">
-      <img
-        [src]="img"
-        alt="Album photo"
-        class="w-full h-full object-contain rounded-none sm:rounded-lg"
-      />
-    </swiper-slide>
-  </swiper-container>
+<div *ngIf="album" class="min-h-screen bg-black p-4">
+  <h2 class="text-2xl sm:text-3xl font-bold text-green-400 mb-4 animate-fade-in-up text-center">{{ album.title }}</h2>
+  <div class="columns-1 sm:columns-2 md:columns-3 gap-4">
+    <img
+      *ngFor="let img of album.images"
+      [src]="img"
+      [alt]="album.title + ' photo'"
+      loading="lazy"
+      class="w-full mb-4 rounded-lg"
+    />
+  </div>
 </div>
 
 <div *ngIf="!album" class="text-center text-green-400 mt-20">

--- a/src/app/pages/album-viewer/album-viewer.component.scss
+++ b/src/app/pages/album-viewer/album-viewer.component.scss
@@ -1,3 +1,7 @@
 :host {
   display: block;
+
+  img {
+    @apply break-inside-avoid;
+  }
 }

--- a/src/app/pages/album-viewer/album-viewer.component.ts
+++ b/src/app/pages/album-viewer/album-viewer.component.ts
@@ -2,7 +2,6 @@ import { Component, OnDestroy } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { ALBUMS, Album } from '../../data/albums';
-import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { AwsS3Service } from '../../services/aws-s3.service';
@@ -13,7 +12,6 @@ import { Title, Meta } from '@angular/platform-browser';
   selector: 'app-album-viewer',
   standalone: true,
   imports: [CommonModule, RouterModule],
-  schemas: [CUSTOM_ELEMENTS_SCHEMA], // needed for swiper web components
   templateUrl: './album-viewer.component.html',
   styleUrls: ['./album-viewer.component.scss']
 })

--- a/src/app/pages/photography/photography.component.html
+++ b/src/app/pages/photography/photography.component.html
@@ -2,17 +2,18 @@
   <h2 class="text-3xl sm:text-4xl font-bold mb-10 text-center">My Photography Albums</h2>
 
   <div
-    class="max-w-4xl mx-auto grid grid-cols-1 sm:grid-cols-2 gap-6 p-4 sm:p-6 md:p-10"
+    class="max-w-4xl mx-auto columns-1 sm:columns-2 lg:columns-3 gap-6 p-4 sm:p-6 md:p-10"
   >
     <a
       *ngFor="let album of albums"
       [routerLink]="['/album', album.id]"
-      class="group rounded-xl overflow-hidden bg-mint shadow-lg hover:shadow-xl transition-transform transform hover:scale-[1.02] border border-transparent hover:border-green-500"
+      class="group block mb-6 break-inside-avoid rounded-xl overflow-hidden bg-mint shadow-lg hover:shadow-xl transition-transform transform hover:scale-[1.02] border border-transparent hover:border-green-500"
     >
       <div class="relative">
         <img
           [src]="album.cover"
           [alt]="album.title"
+          loading="lazy"
           class="w-full h-60 object-cover transition-transform duration-300 group-hover:scale-105"
         />
         <div

--- a/src/app/pages/photography/photography.component.scss
+++ b/src/app/pages/photography/photography.component.scss
@@ -4,6 +4,7 @@
   }
 
   .group {
+    @apply mb-6 break-inside-avoid;
     transition: transform 0.3s ease;
 
     img {


### PR DESCRIPTION
## Summary
- display photography albums using CSS columns for responsive masonry
- remove Swiper slideshow and show album images in a column layout

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864240d39388331943531e085140c60