### PR TITLE
Fix album hover overlay

### DIFF
--- a/src/app/pages/photography/photography.component.html
+++ b/src/app/pages/photography/photography.component.html
@@ -24,7 +24,7 @@
         />
         <div
           *ngIf="!album.images.length"
-          class="absolute inset-0 bg-black/70 flex items-center justify-center text-white font-semibold"
+          class="absolute inset-0 bg-black/70 flex items-center justify-center text-white font-semibold transition-opacity group-hover:opacity-0"
         >
           Coming Soon
         </div>


### PR DESCRIPTION
## Summary
- hide 'Coming Soon' overlay when hovering an album

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d59fded108331b3ed5b08f7771f2e