### PR TITLE
Add scroll hint on photography page

### DIFF
--- a/src/app/pages/photography/photography.component.html
+++ b/src/app/pages/photography/photography.component.html
@@ -39,7 +39,8 @@
       </div>
     </a>
   </div>
-  <div class="sticky bottom-4 mt-4 flex justify-center pointer-events-none sm:hidden">
-    <span class="animate-bounce text-3xl text-emerald">↓</span>
+  <div *ngIf="showScrollHint" class="sticky bottom-4 mt-4 flex flex-col items-center justify-center pointer-events-none text-emerald">
+    <span class="animate-bounce text-3xl">↓</span>
+    <span class="text-sm mt-1">Scroll for more</span>
   </div>
 </section>

--- a/src/app/pages/photography/photography.component.ts
+++ b/src/app/pages/photography/photography.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Component, OnInit, OnDestroy, HostListener } from '@angular/core';
 import { Title, Meta } from '@angular/platform-browser';
 import { ALBUMS, Album } from '../../data/albums';
 import { AwsS3Service } from '../../services/aws-s3.service';
@@ -14,6 +14,7 @@ import { CommonModule } from '@angular/common';
 })
 export class PhotographyComponent implements OnInit, OnDestroy {
   albums: Album[] = [];
+  showScrollHint = false;
   private coverInterval?: ReturnType<typeof setInterval>;
 
   constructor(
@@ -21,6 +22,11 @@ export class PhotographyComponent implements OnInit, OnDestroy {
     private meta: Meta,
     private s3: AwsS3Service
   ) {}
+
+  @HostListener('window:scroll')
+  onScroll() {
+    this.checkScrollHint();
+  }
 
   async ngOnInit() {
     this.titleService.setTitle('Photography - Lowkeyframes');
@@ -72,12 +78,19 @@ export class PhotographyComponent implements OnInit, OnDestroy {
       this.albums = ALBUMS;
     }
     this.startCoverRotation();
+    setTimeout(() => this.checkScrollHint());
   }
 
   ngOnDestroy() {
     if (this.coverInterval) {
       clearInterval(this.coverInterval);
     }
+  }
+
+  private checkScrollHint() {
+    const doc = document.documentElement;
+    const bottom = window.scrollY + window.innerHeight;
+    this.showScrollHint = bottom < doc.scrollHeight - 20;
   }
 
   private startCoverRotation() {


### PR DESCRIPTION
## Summary
- display a bouncing arrow with text when more albums are available
- hide the hint once scrolled near the bottom

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d5c4819b88331a54c3486f67b7b08