### PR TITLE
Update branding and hide portfolio

### DIFF
--- a/src/app/components/footer/footer.component.html
+++ b/src/app/components/footer/footer.component.html
@@ -1,3 +1,3 @@
 <footer class="bg-gray-900 text-gray-400 text-center p-6 mt-12">
-  <p>© {{ currentYear }} LowKey Frames — Crafted with ❤️ by Lokesh</p>
+  <p>© {{ currentYear }} LowKey Frames — Crafted with ❤️ by LowKey Frames</p>
 </footer>

--- a/src/app/components/navbar/navbar.component.html
+++ b/src/app/components/navbar/navbar.component.html
@@ -17,7 +17,6 @@
       class="hidden md:flex space-x-6 text-sm font-medium uppercase tracking-wide text-white">
       <li><a routerLink="/" routerLinkActive="text-green-400">Home</a></li>
       <li><a routerLink="/photography" routerLinkActive="text-green-400">Photography</a></li>
-      <li><a routerLink="/professional" routerLinkActive="text-green-400">Professional</a></li>
       <li><a routerLink="/about" routerLinkActive="text-green-400">About</a></li>
       <li><a routerLink="/contact" routerLinkActive="text-green-400">Contact</a></li>
     </ul>
@@ -28,7 +27,6 @@
     <ul class="flex flex-col px-4 py-2 space-y-2">
       <li><a (click)="closeMenu()" routerLink="/">Home</a></li>
       <li><a (click)="closeMenu()" routerLink="/photography">Photography</a></li>
-      <li><a (click)="closeMenu()" routerLink="/professional">Professional</a></li>
       <li><a (click)="closeMenu()" routerLink="/about">About</a></li>
       <li><a (click)="closeMenu()" routerLink="/contact">Contact</a></li>
     </ul>

--- a/src/app/data/projects.ts
+++ b/src/app/data/projects.ts
@@ -10,7 +10,7 @@ export const PROJECTS: Project[] = [
     title: 'Portfolio Website',
     image: '/assets/projects/portfolio.jpg',
     description: 'A personal portfolio site built with Angular 17, Tailwind CSS, and hosted on AWS.',
-    link: 'https://lokeshpaduchuri.com'
+    link: 'https://lowkeyframes.com'
   },
   {
     title: 'Photography Showcase',

--- a/src/app/pages/about/about.component.html
+++ b/src/app/pages/about/about.component.html
@@ -1,7 +1,7 @@
 <section class="min-h-screen bg-lavender text-charcoal px-4 py-12">
   <img
     src="/assets/photos/photo1.jpg"
-    alt="Lokesh smiling while working"
+    alt="LowKey Frames capturing a moment"
     class="mx-auto mb-6 w-32 h-32 rounded-full object-cover shadow-md sticky top-0 z-10 sm:w-48 sm:h-48 sm:float-right sm:mb-4 sm:ml-6 sm:static"
   />
   <h2 class="text-4xl font-extrabold mb-6 text-center text-emerald">About Me</h2>
@@ -11,7 +11,7 @@
       style="--chars:79"
       (animationend)="typingDone = true"
       [class.done]="typingDone"
-      >Hey, I&rsquo;m Lokesh &ndash; but most people know me through the moments I freeze in time.</span
+      >Hey, we&rsquo;re LowKey Frames &ndash; your creative partners in capturing moments.</span
     >
   </p>
   <p class="mb-4 animate-fade-in-up opacity-0" style="animation-delay:4s">By profession, I&rsquo;m a web architect &mdash; building sleek, smart digital spaces. But my heart? It belongs to the camera.</p>

--- a/src/app/pages/about/about.component.ts
+++ b/src/app/pages/about/about.component.ts
@@ -15,7 +15,7 @@ export class AboutComponent implements OnInit {
 
   ngOnInit() {
     this.titleService.setTitle('About - Lowkeyframes');
-    this.meta.updateTag({ name: 'description', content: 'Learn more about Lokesh and the philosophy behind Lowkeyframes.' });
+    this.meta.updateTag({ name: 'description', content: 'Learn more about LowKey Frames and the philosophy behind Lowkeyframes.' });
   }
 }
 

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -1,7 +1,7 @@
 <!-- Hero Section -->
 <section class="relative min-h-screen bg-cover bg-center bg-no-repeat px-4" style="background-image: url('/assets/hero.jpg')">
   <div class="absolute inset-0 bg-black bg-opacity-60 flex flex-col items-center justify-center text-center text-white px-4">
-    <h1 class="text-4xl sm:text-6xl font-bold mb-4">Lokesh Paduchuri</h1>
+    <h1 class="text-4xl sm:text-6xl font-bold mb-4">LowKey Frames</h1>
     <p class="text-xl sm:text-2xl mb-10"><span class="typing">Capturing stories — in life, light, and lines.</span></p>
     <a href="#scroll-cards" class="animate-bounce text-2xl mt-10 hover:text-emerald transition">↓</a>
   </div>

--- a/src/index.html
+++ b/src/index.html
@@ -6,7 +6,7 @@
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Capture heartfelt moments with Low Key Frames in McKinney. Book your family photo session today!">
-  <meta name="description" content="Portfolio of Lokesh Paduchuri – photography and professional projects">
+  <meta name="description" content="Portfolio of LowKey Frames – photography and professional projects">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
 </head>
 <body>


### PR DESCRIPTION
## Summary
- drop the Professional link from the navbar so the portfolio tab is hidden
- use LowKey Frames branding throughout the site
- update contact link in projects data

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_687028edc0588331aa14a735c4aceedb