### PR TITLE
Add new pages and routing

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -5,12 +5,20 @@ import { ProfessionalComponent } from './pages/professional/professional.compone
 import { ContactComponent } from './pages/contact/contact.component';
 import { AboutComponent } from './pages/about/about.component';
 import { AlbumViewerComponent } from './pages/album-viewer/album-viewer.component'; // new
+import { PortfolioComponent } from './pages/portfolio/portfolio.component';
+import { PackagesComponent } from './pages/packages/packages.component';
+import { ReviewsComponent } from './pages/reviews/reviews.component';
+import { BlogComponent } from './pages/blog/blog.component';
 
 export const routes: Routes = [
   { path: '', component: HomeComponent, data: { animation: 'HomePage' } },
   { path: 'about', component: AboutComponent, data: { animation: 'AboutPage' } },
   { path: 'photography', component: PhotographyComponent, data: { animation: 'PhotographyPage' } },
   { path: 'professional', component: ProfessionalComponent, data: { animation: 'ProfessionalPage' } },
+  { path: 'portfolio', component: PortfolioComponent, data: { animation: 'PortfolioPage' } },
+  { path: 'packages', component: PackagesComponent, data: { animation: 'PackagesPage' } },
+  { path: 'reviews', component: ReviewsComponent, data: { animation: 'ReviewsPage' } },
+  { path: 'blog', component: BlogComponent, data: { animation: 'BlogPage' } },
   { path: 'contact', component: ContactComponent, data: { animation: 'ContactPage' } },
 
   // New route for album carousel view

--- a/src/app/components/navbar/navbar.component.html
+++ b/src/app/components/navbar/navbar.component.html
@@ -16,7 +16,10 @@
     <ul
       class="hidden md:flex space-x-6 text-sm font-medium uppercase tracking-wide text-white">
       <li><a routerLink="/" routerLinkActive="text-green-400">Home</a></li>
-      <li><a routerLink="/photography" routerLinkActive="text-green-400">Photography</a></li>
+      <li><a routerLink="/portfolio" routerLinkActive="text-green-400">Portfolio</a></li>
+      <li><a routerLink="/packages" routerLinkActive="text-green-400">Packages</a></li>
+      <li><a routerLink="/reviews" routerLinkActive="text-green-400">Reviews</a></li>
+      <li><a routerLink="/blog" routerLinkActive="text-green-400">Blog</a></li>
       <li><a routerLink="/about" routerLinkActive="text-green-400">About</a></li>
       <li><a routerLink="/contact" routerLinkActive="text-green-400">Contact</a></li>
     </ul>
@@ -26,7 +29,10 @@
   <div *ngIf="menuOpen" class="md:hidden bg-black border-t border-gray-700">
     <ul class="flex flex-col px-4 py-2 space-y-2">
       <li><a (click)="closeMenu()" routerLink="/">Home</a></li>
-      <li><a (click)="closeMenu()" routerLink="/photography">Photography</a></li>
+      <li><a (click)="closeMenu()" routerLink="/portfolio">Portfolio</a></li>
+      <li><a (click)="closeMenu()" routerLink="/packages">Packages</a></li>
+      <li><a (click)="closeMenu()" routerLink="/reviews">Reviews</a></li>
+      <li><a (click)="closeMenu()" routerLink="/blog">Blog</a></li>
       <li><a (click)="closeMenu()" routerLink="/about">About</a></li>
       <li><a (click)="closeMenu()" routerLink="/contact">Contact</a></li>
     </ul>

--- a/src/app/pages/blog/blog.component.html
+++ b/src/app/pages/blog/blog.component.html
@@ -1,0 +1,4 @@
+<section class="min-h-screen bg-aqua text-charcoal px-4 py-12">
+  <h2 class="text-3xl sm:text-4xl font-bold text-center mb-8">Blog</h2>
+  <p class="text-center">Stay tuned for upcoming posts and Instagram highlights.</p>
+</section>

--- a/src/app/pages/blog/blog.component.scss
+++ b/src/app/pages/blog/blog.component.scss
@@ -1,0 +1,1 @@
+/* Styles for blog page */

--- a/src/app/pages/blog/blog.component.ts
+++ b/src/app/pages/blog/blog.component.ts
@@ -1,0 +1,19 @@
+import { Component, OnInit } from '@angular/core';
+import { Title, Meta } from '@angular/platform-browser';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-blog',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './blog.component.html',
+  styleUrls: ['./blog.component.scss']
+})
+export class BlogComponent implements OnInit {
+  constructor(private titleService: Title, private meta: Meta) {}
+
+  ngOnInit() {
+    this.titleService.setTitle('Blog - Lowkeyframes');
+    this.meta.updateTag({ name: 'description', content: 'Latest updates and behind-the-scenes stories.' });
+  }
+}

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -2,22 +2,22 @@
 <section class="relative min-h-screen bg-cover bg-center bg-no-repeat px-4" style="background-image: url('/assets/hero.jpg')">
   <div class="absolute inset-0 bg-black bg-opacity-60 flex flex-col items-center justify-center text-center text-white px-4">
     <h1 class="text-4xl sm:text-6xl font-bold mb-4">LowKey Frames</h1>
-    <p class="text-xl sm:text-2xl mb-10"><span class="typing">Capturing stories — in life, light, and lines.</span></p>
+    <p class="text-xl sm:text-2xl mb-10"><span class="typing">Moments, Framed with Feeling</span></p>
     <a href="#scroll-cards" class="animate-bounce text-2xl mt-10 hover:text-emerald transition">↓</a>
   </div>
 </section>
 
 <!-- Scroll Cards -->
 <section id="scroll-cards" class="bg-ivory text-charcoal py-16 px-4 sm:px-6 grid gap-6 gap-y-10 sm:grid-cols-2">
-  <!-- Photography -->
-  <a [routerLink]="['/photography']" class="group block p-8 rounded-2xl bg-mint shadow-md hover:shadow-xl transition-transform hover:scale-105">
-    <h2 class="text-3xl font-semibold text-emerald mb-4 group-hover:underline">📸 Photography</h2>
-    <p>Albums, stories, portraits, and everything visual.</p>
+  <!-- Portfolio -->
+  <a [routerLink]="['/portfolio']" class="group block p-8 rounded-2xl bg-mint shadow-md hover:shadow-xl transition-transform hover:scale-105">
+    <h2 class="text-3xl font-semibold text-emerald mb-4 group-hover:underline">📸 View Portfolio</h2>
+    <p>Featured albums and galleries.</p>
   </a>
 
-  <!-- Professional -->
-  <a [routerLink]="['/professional']" class="group block p-8 rounded-2xl bg-aqua shadow-md hover:shadow-xl transition-transform hover:scale-105">
-    <h2 class="text-3xl font-semibold text-emerald mb-4 group-hover:underline">💼 Professional Work</h2>
-    <p>My experience, side projects, and contributions.</p>
+  <!-- Packages -->
+  <a [routerLink]="['/packages']" class="group block p-8 rounded-2xl bg-aqua shadow-md hover:shadow-xl transition-transform hover:scale-105">
+    <h2 class="text-3xl font-semibold text-emerald mb-4 group-hover:underline">💼 Book a Session</h2>
+    <p>Browse packages and availability.</p>
   </a>
 </section>

--- a/src/app/pages/packages/packages.component.html
+++ b/src/app/pages/packages/packages.component.html
@@ -1,0 +1,15 @@
+<section class="min-h-screen bg-ivory text-charcoal px-4 py-12">
+  <h2 class="text-3xl sm:text-4xl font-bold text-center mb-8">Packages & Booking</h2>
+  <div class="max-w-3xl mx-auto space-y-6">
+    <div class="bg-mint p-6 rounded-lg shadow">
+      <h3 class="text-xl font-semibold mb-2">Mini Session</h3>
+      <p class="mb-2">30 minutes, 10 edited images</p>
+      <p class="font-bold">$200</p>
+    </div>
+    <div class="bg-mint p-6 rounded-lg shadow">
+      <h3 class="text-xl font-semibold mb-2">Full Session</h3>
+      <p class="mb-2">1 hour, 25 edited images</p>
+      <p class="font-bold">$400</p>
+    </div>
+  </div>
+</section>

--- a/src/app/pages/packages/packages.component.scss
+++ b/src/app/pages/packages/packages.component.scss
@@ -1,0 +1,1 @@
+/* Styles for packages page */

--- a/src/app/pages/packages/packages.component.ts
+++ b/src/app/pages/packages/packages.component.ts
@@ -1,0 +1,19 @@
+import { Component, OnInit } from '@angular/core';
+import { Title, Meta } from '@angular/platform-browser';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-packages',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './packages.component.html',
+  styleUrls: ['./packages.component.scss']
+})
+export class PackagesComponent implements OnInit {
+  constructor(private titleService: Title, private meta: Meta) {}
+
+  ngOnInit() {
+    this.titleService.setTitle('Packages - Lowkeyframes');
+    this.meta.updateTag({ name: 'description', content: 'Photography session packages and booking information.' });
+  }
+}

--- a/src/app/pages/portfolio/portfolio.component.html
+++ b/src/app/pages/portfolio/portfolio.component.html
@@ -1,0 +1,45 @@
+<section class="min-h-screen bg-lemon text-emerald px-4 sm:px-8 py-12">
+  <h2 class="text-3xl sm:text-4xl font-bold text-center mb-4">Portfolio</h2>
+  <ul class="text-center mb-10 space-y-1">
+    <li>🧡 <span class="font-semibold">Family &amp; Kids</span></li>
+    <li>💍 <span class="font-semibold">Events &amp; Celebrations</span></li>
+    <li>✨ <span class="font-semibold">Fashion &amp; Editorial</span></li>
+    <li>🌄 <span class="font-semibold">Travel &amp; Landscape</span></li>
+  </ul>
+
+  <div
+    class="max-w-5xl mx-auto grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 p-4 sm:p-6 md:p-10"
+  >
+    <a
+      *ngFor="let album of albums"
+      [routerLink]="['/album', album.id]"
+      class="group block mb-6 break-inside-avoid rounded-xl overflow-hidden bg-mint shadow-lg hover:shadow-xl transition-transform transform hover:scale-[1.02] border border-transparent hover:border-green-500"
+    >
+      <div class="relative">
+        <img
+          [src]="album.cover"
+          [alt]="album.title"
+          loading="lazy"
+          class="w-full h-60 object-cover transition-transform duration-300 group-hover:scale-105"
+        />
+        <div
+          *ngIf="!album.images.length"
+          class="absolute inset-0 bg-black/70 flex items-center justify-center text-white font-semibold transition-opacity group-hover:opacity-0"
+        >
+          Coming Soon
+        </div>
+        <div
+          class="absolute inset-0 bg-black/50 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity"
+        >
+          <h3 class="text-xl font-semibold text-white">{{ album.title }}</h3>
+        </div>
+      </div>
+      <div class="p-4">
+        <p class="text-charcoal text-sm">{{ album.description }}</p>
+      </div>
+    </a>
+  </div>
+  <div class="sticky bottom-4 mt-4 flex justify-center pointer-events-none sm:hidden">
+    <span class="animate-bounce text-3xl text-emerald">↓</span>
+  </div>
+</section>

--- a/src/app/pages/portfolio/portfolio.component.scss
+++ b/src/app/pages/portfolio/portfolio.component.scss
@@ -1,0 +1,24 @@
+:host {
+  section {
+    @apply min-h-screen bg-zinc-900 text-white;
+  }
+
+  .group {
+    @apply mb-6 break-inside-avoid;
+    transition: transform 0.3s ease;
+
+    img {
+      transition: transform 0.3s ease;
+    }
+
+    &:hover {
+      img {
+        transform: scale(1.05);
+      }
+
+      .absolute {
+        opacity: 1;
+      }
+    }
+  }
+}

--- a/src/app/pages/portfolio/portfolio.component.spec.ts
+++ b/src/app/pages/portfolio/portfolio.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PortfolioComponent } from './portfolio.component';
+
+describe('PortfolioComponent', () => {
+  let component: PortfolioComponent;
+  let fixture: ComponentFixture<PortfolioComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [PortfolioComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(PortfolioComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/pages/portfolio/portfolio.component.ts
+++ b/src/app/pages/portfolio/portfolio.component.ts
@@ -1,0 +1,96 @@
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Title, Meta } from '@angular/platform-browser';
+import { ALBUMS, Album } from '../../data/albums';
+import { AwsS3Service } from '../../services/aws-s3.service';
+import { environment } from '../../../environments/environment';
+import { RouterModule } from '@angular/router';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  standalone: true,
+  selector: 'app-portfolio',
+  imports: [RouterModule, CommonModule],
+  templateUrl: './portfolio.component.html',
+})
+export class PortfolioComponent implements OnInit, OnDestroy {
+  albums: Album[] = [];
+  private coverInterval?: ReturnType<typeof setInterval>;
+
+  constructor(
+    private titleService: Title,
+    private meta: Meta,
+    private s3: AwsS3Service
+  ) {}
+
+  async ngOnInit() {
+    this.titleService.setTitle('Portfolio - Lowkeyframes');
+    this.meta.updateTag({ name: 'description', content: 'Browse portfolio albums showcasing diverse stories and portraits.' });
+
+    try {
+      const bucket = environment.aws.bucket;
+      const ids = await this.s3.listAlbums(bucket);
+      if (ids.length) {
+        const fetched = await Promise.all(
+          ids.map(async id => {
+            const s3Images = await this.s3.listObjects(bucket, `${id}/`);
+            const local = ALBUMS.find(a => a.id === id);
+            const images = s3Images.length ? s3Images : local?.images || [];
+
+            if (!images.length) {
+              return null;
+            }
+
+            const coverFromS3 = s3Images.find(img => img.includes('cover'));
+            const cover = coverFromS3 || local?.cover || images[0];
+            const title = local?.title || id.replace(/-/g, ' ');
+            const description = local?.description || '';
+
+            return {
+              id,
+              title,
+              description,
+              cover,
+              coverIndex: coverFromS3 ? images.indexOf(coverFromS3) : local?.coverIndex,
+              images
+            } as Album;
+          })
+        );
+
+        const fetchedAlbums = fetched.filter((a): a is Album => !!a);
+        const map = new Map(fetchedAlbums.map(a => [a.id, a]));
+        this.albums = ALBUMS.map(a => map.get(a.id) || a);
+        fetchedAlbums.forEach(a => {
+          if (!ALBUMS.find(alb => alb.id === a.id)) {
+            this.albums.push(a);
+          }
+        });
+      } else {
+        this.albums = ALBUMS;
+      }
+    } catch (err) {
+      console.error('Failed to load albums', err);
+      this.albums = ALBUMS;
+    }
+    this.startCoverRotation();
+  }
+
+  ngOnDestroy() {
+    if (this.coverInterval) {
+      clearInterval(this.coverInterval);
+    }
+  }
+
+  private startCoverRotation() {
+    this.coverInterval = setInterval(() => {
+      this.albums.forEach(album => {
+        if (album.images && album.images.length > 1) {
+          const idx = typeof album.coverIndex === 'number' ? album.coverIndex : 0;
+          const next = (idx + 1) % album.images.length;
+          album.coverIndex = next;
+          album.cover = album.images[next];
+        }
+      });
+    }, 5000);
+  }
+}
+

--- a/src/app/pages/reviews/reviews.component.html
+++ b/src/app/pages/reviews/reviews.component.html
@@ -1,0 +1,13 @@
+<section class="min-h-screen bg-lavender text-charcoal px-4 py-12">
+  <h2 class="text-3xl sm:text-4xl font-bold text-center mb-8">Client Reviews</h2>
+  <div class="max-w-3xl mx-auto space-y-6">
+    <blockquote class="bg-white p-6 rounded-lg shadow">
+      <p class="mb-2">“Amazing experience and beautiful photos!”</p>
+      <footer class="text-sm font-semibold">— Happy Client</footer>
+    </blockquote>
+    <blockquote class="bg-white p-6 rounded-lg shadow">
+      <p class="mb-2">“Captured our family perfectly.”</p>
+      <footer class="text-sm font-semibold">— Another Client</footer>
+    </blockquote>
+  </div>
+</section>

--- a/src/app/pages/reviews/reviews.component.scss
+++ b/src/app/pages/reviews/reviews.component.scss
@@ -1,0 +1,1 @@
+/* Styles for reviews page */

--- a/src/app/pages/reviews/reviews.component.ts
+++ b/src/app/pages/reviews/reviews.component.ts
@@ -1,0 +1,19 @@
+import { Component, OnInit } from '@angular/core';
+import { Title, Meta } from '@angular/platform-browser';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-reviews',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './reviews.component.html',
+  styleUrls: ['./reviews.component.scss']
+})
+export class ReviewsComponent implements OnInit {
+  constructor(private titleService: Title, private meta: Meta) {}
+
+  ngOnInit() {
+    this.titleService.setTitle('Client Reviews - Lowkeyframes');
+    this.meta.updateTag({ name: 'description', content: 'Testimonials from photography clients.' });
+  }
+}


### PR DESCRIPTION
## Summary
- create new Portfolio, Packages, Reviews and Blog pages
- update navbar links to point to the new pages
- tweak Home page tagline and calls to action
- extend routing configuration for the new pages

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68713cd12314833189db11838cf4ae78