### PR TITLE
Guard browser-only APIs

### DIFF
--- a/src/app/components/in-view.directive.ts
+++ b/src/app/components/in-view.directive.ts
@@ -1,4 +1,5 @@
-import { Directive, ElementRef, EventEmitter, OnDestroy, OnInit, Output } from '@angular/core';
+import { Directive, ElementRef, EventEmitter, Inject, OnDestroy, OnInit, Output, PLATFORM_ID } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
 
 @Directive({
   selector: '[appInView]',
@@ -8,18 +9,22 @@ export class InViewDirective implements OnInit, OnDestroy {
   @Output() inViewChange = new EventEmitter<boolean>();
   private observer?: IntersectionObserver;
 
-  constructor(private el: ElementRef) {}
+  constructor(private el: ElementRef, @Inject(PLATFORM_ID) private platformId: Object) {}
 
   ngOnInit() {
-    this.observer = new IntersectionObserver(entries => {
-      entries.forEach(entry => {
-        if (entry.isIntersecting) {
-          this.inViewChange.emit(true);
-          this.observer?.disconnect();
-        }
-      });
-    }, { threshold: 0.1 });
-    this.observer.observe(this.el.nativeElement);
+    if (isPlatformBrowser(this.platformId) && typeof IntersectionObserver !== 'undefined') {
+      this.observer = new IntersectionObserver(entries => {
+        entries.forEach(entry => {
+          if (entry.isIntersecting) {
+            this.inViewChange.emit(true);
+            this.observer?.disconnect();
+          }
+        });
+      }, { threshold: 0.1 });
+      this.observer.observe(this.el.nativeElement);
+    } else {
+      this.inViewChange.emit(true);
+    }
   }
 
   ngOnDestroy() {

--- a/src/app/pages/photography/photography.component.ts
+++ b/src/app/pages/photography/photography.component.ts
@@ -1,5 +1,6 @@
-import { Component, OnInit, OnDestroy, HostListener } from '@angular/core';
+import { Component, OnInit, OnDestroy, HostListener, Inject, PLATFORM_ID } from '@angular/core';
 import { Title, Meta } from '@angular/platform-browser';
+import { isPlatformBrowser } from '@angular/common';
 import { ALBUMS, Album } from '../../data/albums';
 import { AwsS3Service } from '../../services/aws-s3.service';
 import { environment } from '../../../environments/environment';
@@ -20,7 +21,8 @@ export class PhotographyComponent implements OnInit, OnDestroy {
   constructor(
     private titleService: Title,
     private meta: Meta,
-    private s3: AwsS3Service
+    private s3: AwsS3Service,
+    @Inject(PLATFORM_ID) private platformId: Object
   ) {}
 
   @HostListener('window:scroll')
@@ -78,7 +80,9 @@ export class PhotographyComponent implements OnInit, OnDestroy {
       this.albums = ALBUMS;
     }
     this.startCoverRotation();
-    setTimeout(() => this.checkScrollHint());
+    if (isPlatformBrowser(this.platformId)) {
+      setTimeout(() => this.checkScrollHint());
+    }
   }
 
   ngOnDestroy() {
@@ -88,6 +92,9 @@ export class PhotographyComponent implements OnInit, OnDestroy {
   }
 
   private checkScrollHint() {
+    if (!isPlatformBrowser(this.platformId)) {
+      return;
+    }
     const doc = document.documentElement;
     const bottom = window.scrollY + window.innerHeight;
     this.showScrollHint = bottom < doc.scrollHeight - 20;


### PR DESCRIPTION
## Summary
- prevent server-side build errors by skipping IntersectionObserver on the server
- avoid document and window access unless running in the browser

## Testing
- `npm test` *(fails: sh: 1: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a62ce47f148331ae129ff7774b99a7