### PR TITLE
Hide contact form after submission

### DIFF
--- a/src/app/pages/contact/contact.component.html
+++ b/src/app/pages/contact/contact.component.html
@@ -8,7 +8,7 @@
   <p class="contact__subtitle">Let us tell your story — just pick how it starts.</p>
   <p *ngIf="submitted" class="contact__success">Hey {{ submittedName || 'friend' }}! 🎞️ Thanks for reaching out — can’t wait to frame your story.</p>
 
-  <div *ngIf="step === 1" @fade class="contact__categories">
+  <div *ngIf="step === 1 && !submitted" @fade class="contact__categories">
     <p class="contact__question">What are you looking for?</p>
     <div class="contact__grid">
       <button
@@ -22,7 +22,7 @@
     </div>
   </div>
 
-  <form *ngIf="step === 2" #form="ngForm" @fade (ngSubmit)="onSubmitForm()" class="contact__form">
+  <form *ngIf="step === 2 && !submitted" #form="ngForm" @fade (ngSubmit)="onSubmitForm()" class="contact__form">
     <button type="button" class="contact__back" (click)="backToCategories()">← back</button>
     <p class="contact__intro">
       <span class="contact__intro-emoji">{{ selectedCategory?.icon }}</span>

--- a/src/app/pages/contact/contact.component.html
+++ b/src/app/pages/contact/contact.component.html
@@ -8,7 +8,7 @@
   <p class="contact__subtitle">Let us tell your story — just pick how it starts.</p>
   <p *ngIf="submitted" class="contact__success">Hey {{ submittedName || 'friend' }}! 🎞️ Thanks for reaching out — can’t wait to frame your story.</p>
 
-  <div *ngIf="step === 1 && !submitted" @fade class="contact__categories">
+  <div *ngIf="step === 1" @fade class="contact__categories">
     <p class="contact__question">What are you looking for?</p>
     <div class="contact__grid">
       <button

--- a/src/app/pages/contact/contact.component.scss
+++ b/src/app/pages/contact/contact.component.scss
@@ -42,7 +42,7 @@
   display: grid;
   gap: 1rem;
   grid-template-columns: 1fr;
-  justify-items: center;
+  justify-items: stretch;
 }
 
 @media (min-width: 600px) {
@@ -60,6 +60,7 @@
 .contact__category {
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: 0.5rem;
   padding: 1rem;
   border: 1px solid #ddd;
@@ -68,6 +69,7 @@
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
   transition: transform 0.2s, box-shadow 0.2s, border-color 0.2s;
   cursor: pointer;
+  width: 100%;
 }
 
 .contact__category-emoji {
@@ -123,6 +125,7 @@
 
 .contact__success {
   text-align: center;
+  color: #4ADE80;
 }
 
 .contact__back {

--- a/src/app/pages/contact/contact.component.ts
+++ b/src/app/pages/contact/contact.component.ts
@@ -129,8 +129,8 @@ export class ContactComponent implements OnInit {
     this.http.post('https://formsubmit.co/lowkeyframestx@gmail.com', data).subscribe({
       next: () => {
         this.submittedName = this.name;
-        this.resetForm();
         this.submitted = true;
+        this.resetForm();
         if (typeof window !== 'undefined') {
           setTimeout(() => {
             this.submitted = false;

--- a/src/app/pages/contact/contact.component.ts
+++ b/src/app/pages/contact/contact.component.ts
@@ -124,9 +124,8 @@ export class ContactComponent implements OnInit {
     data.append('_captcha', 'false');
     data.append('_template', 'box');
     data.append('_subject', 'New Inquiry from LowKey Frames');
-    data.append('_next', 'https://lowkeyframes.com/thank-you');
 
-    this.http.post('https://formsubmit.co/lowkeyframestx@gmail.com', data).subscribe({
+    this.http.post('https://formsubmit.co/ajax/lowkeyframestx@gmail.com', data).subscribe({
       next: () => {
         this.submittedName = this.name;
         this.submitted = true;


### PR DESCRIPTION
## Summary
- hide contact categories and form once submission is acknowledged so only the thank-you message remains
- set submitted state before clearing form fields to prevent flicker after send

## Testing
- `npm test` *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7683f215883319446f03607a06386