### PR TITLE
Add album engagement toast on album pages

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,8 +1,9 @@
 import { Component } from '@angular/core';
 import { Router, RouterOutlet, Scroll } from '@angular/router';
 import { trigger, transition, style, animate, query, group } from '@angular/animations';
-import { NavbarComponent } from "./components/navbar/navbar.component";
-import { FooterComponent } from "./components/footer/footer.component";
+import { NavbarComponent } from './components/navbar/navbar.component';
+import { FooterComponent } from './components/footer/footer.component';
+import { EngagementToastComponent } from './components/engagement-toast/engagement-toast.component';
 import { ViewportScroller } from '@angular/common';
 import { filter } from 'rxjs';
 
@@ -10,13 +11,14 @@ import { filter } from 'rxjs';
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [RouterOutlet, NavbarComponent, FooterComponent],
+  imports: [RouterOutlet, NavbarComponent, FooterComponent, EngagementToastComponent],
   template: `
     <app-navbar></app-navbar>
     <main class="pt-10 min-h-[calc(100vh-4rem)] text-white" [@routeAnimations]="prepareRoute(outlet)">
   <router-outlet #outlet="outlet"></router-outlet>
 </main>
     <app-footer></app-footer>
+    <app-engagement-toast></app-engagement-toast>
   `,
   animations: [
   trigger('routeAnimations', [
@@ -64,3 +66,4 @@ export class AppComponent {
     return outlet?.activatedRouteData?.['animation'] || null;
   }
 }
+

--- a/src/app/components/engagement-toast/engagement-toast.component.html
+++ b/src/app/components/engagement-toast/engagement-toast.component.html
@@ -1,0 +1,16 @@
+<div
+  *ngIf="toast"
+  #toastEl
+  class="fixed bottom-0 right-0 w-full md:w-80 p-4 md:mb-4 md:mr-4 bg-gray-800 text-white rounded shadow-lg transition duration-300" role="dialog" aria-live="polite">
+  <h2 class="text-lg font-semibold mb-2">{{ toast.title }}</h2>
+  <p class="mb-4">{{ toast.message }}</p>
+  <div class="flex flex-col sm:flex-row gap-2">
+    <button class="bg-green-600 hover:bg-green-700 text-black px-3 py-2 rounded focus:outline-none" (click)="contact()">
+      {{ toast.ctaLabel }}
+    </button>
+    <button class="bg-gray-700 hover:bg-gray-600 text-white px-3 py-2 rounded focus:outline-none" (click)="notNow()">
+      Not now
+    </button>
+  </div>
+  <button class="absolute top-2 right-2 text-white" (click)="close()" aria-label="Close">✕</button>
+</div>

--- a/src/app/components/engagement-toast/engagement-toast.component.scss
+++ b/src/app/components/engagement-toast/engagement-toast.component.scss
@@ -1,0 +1,2 @@
+/* TailwindCSS handles styling */
+

--- a/src/app/components/engagement-toast/engagement-toast.component.ts
+++ b/src/app/components/engagement-toast/engagement-toast.component.ts
@@ -1,0 +1,100 @@
+import { Component, ElementRef, HostListener, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Router } from '@angular/router';
+import { Subscription } from 'rxjs';
+import { ToastService, ToastConfig } from '../../services/toast.service';
+import { AlbumEngagementService } from '../../services/album-engagement.service';
+
+@Component({
+  selector: 'app-engagement-toast',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './engagement-toast.component.html',
+  styleUrls: ['./engagement-toast.component.scss']
+})
+export class EngagementToastComponent implements OnInit, OnDestroy {
+  toast: ToastConfig | null = null;
+  private sub?: Subscription;
+  @ViewChild('toastEl') toastEl?: ElementRef<HTMLElement>;
+
+  constructor(
+    private toastService: ToastService,
+    private albumEngagement: AlbumEngagementService,
+    private router: Router
+  ) {}
+
+  ngOnInit(): void {
+    this.sub = this.toastService.toast$.subscribe(t => {
+      this.toast = t;
+      if (t) {
+        setTimeout(() => this.focusFirst(), 0);
+      }
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.sub?.unsubscribe();
+  }
+
+  close(): void {
+    this.toastService.close();
+  }
+
+  contact(): void {
+    if (!this.toast) {
+      return;
+    }
+    if (this.toast.albumId) {
+      this.albumEngagement.markContact(this.toast.albumId);
+    }
+    this.router.navigate(['/contact'], {
+      queryParams: { albumId: this.toast.albumId, albumTitle: this.toast.albumTitle }
+    });
+    this.close();
+  }
+
+  notNow(): void {
+    if (this.toast?.albumId) {
+      this.albumEngagement.suppress(this.toast.albumId);
+    }
+    this.close();
+  }
+
+  @HostListener('document:keydown', ['$event'])
+  handleKeydown(ev: KeyboardEvent): void {
+    if (!this.toast) {
+      return;
+    }
+    if (ev.key === 'Escape') {
+      ev.preventDefault();
+      this.close();
+    } else if (ev.key === 'Tab') {
+      this.trapFocus(ev);
+    }
+  }
+
+  private focusFirst(): void {
+    const el = this.toastEl?.nativeElement;
+    const focusable = el?.querySelectorAll<HTMLElement>('button, [href], [tabindex]:not([tabindex="-1"])');
+    focusable && focusable[0]?.focus();
+  }
+
+  private trapFocus(ev: KeyboardEvent): void {
+    const el = this.toastEl?.nativeElement;
+    const focusable = el?.querySelectorAll<HTMLElement>('button, [href], [tabindex]:not([tabindex="-1"])');
+    if (!focusable || focusable.length === 0) {
+      return;
+    }
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    const active = document.activeElement as HTMLElement;
+    if (!ev.shiftKey && active === last) {
+      ev.preventDefault();
+      first.focus();
+    } else if (ev.shiftKey && active === first) {
+      ev.preventDefault();
+      last.focus();
+    }
+  }
+}
+

--- a/src/app/pages/album-viewer/album-viewer.component.ts
+++ b/src/app/pages/album-viewer/album-viewer.component.ts
@@ -7,6 +7,7 @@ import { RouterModule } from '@angular/router';
 import { AwsS3Service } from '../../services/aws-s3.service';
 import { environment } from '../../../environments/environment';
 import { SeoService } from '../../services/seo.service';
+import { AlbumEngagementService } from '../../services/album-engagement.service';
 
 @Component({
   selector: 'app-album-viewer',
@@ -23,7 +24,8 @@ export class AlbumViewerComponent implements OnDestroy {
     private route: ActivatedRoute,
     private router: Router,
     private s3: AwsS3Service,
-    private seo: SeoService
+    private seo: SeoService,
+    private albumEngagement: AlbumEngagementService
   ) {
     this.paramSub = this.route.params.subscribe(async params => {
       const id = params['id'];
@@ -64,6 +66,7 @@ export class AlbumViewerComponent implements OnDestroy {
           { name: 'Portfolio', url: 'https://lowkeyframes.com/portfolio' },
           { name: this.album.title, url: `https://lowkeyframes.com/album/${id}` }
         ]);
+        this.albumEngagement.initTimer(id, this.album.title);
       } catch (err) {
         console.error('Failed to load S3 objects', err);
       }
@@ -72,6 +75,7 @@ export class AlbumViewerComponent implements OnDestroy {
 
   ngOnDestroy() {
     this.paramSub?.unsubscribe();
+    this.albumEngagement.destroy();
   }
 
   goBack() {
@@ -80,3 +84,4 @@ export class AlbumViewerComponent implements OnDestroy {
     }
   }
 }
+

--- a/src/app/services/album-engagement.service.ts
+++ b/src/app/services/album-engagement.service.ts
@@ -1,0 +1,110 @@
+import { Injectable } from '@angular/core';
+import { ToastService } from './toast.service';
+
+@Injectable({ providedIn: 'root' })
+export class AlbumEngagementService {
+  private timerId: ReturnType<typeof setInterval> | null = null;
+  private activeSeconds = 0;
+  private isVisible = true;
+  private isFocused = true;
+  private albumId?: string;
+  private albumTitle?: string;
+
+  constructor(private toast: ToastService) {}
+
+  initTimer(albumId: string, albumTitle: string): void {
+    this.destroy();
+    this.albumId = albumId;
+    this.albumTitle = albumTitle;
+    if (this.isSuppressed(albumId) || this.hasContacted(albumId)) {
+      return;
+    }
+    this.handleVisibility = this.handleVisibility.bind(this);
+    document.addEventListener('visibilitychange', this.handleVisibility);
+    window.addEventListener('focus', this.handleVisibility);
+    window.addEventListener('blur', this.handleVisibility);
+    this.timerId = setInterval(() => {
+      if (this.isActive()) {
+        this.activeSeconds++;
+        if (this.activeSeconds >= 30 && this.albumId && this.albumTitle) {
+          this.toast.open({
+            title: `Loving the ${this.albumTitle} album?`,
+            message: 'If this vibe fits your story, I can tailor a session just for you. Want to chat?',
+            ctaLabel: 'Contact us',
+            albumId: this.albumId,
+            albumTitle: this.albumTitle
+          });
+          this.destroy();
+        }
+      }
+    }, 1000);
+  }
+
+  destroy(): void {
+    if (this.timerId) {
+      clearInterval(this.timerId);
+      this.timerId = null;
+    }
+    document.removeEventListener('visibilitychange', this.handleVisibility);
+    window.removeEventListener('focus', this.handleVisibility);
+    window.removeEventListener('blur', this.handleVisibility);
+    this.activeSeconds = 0;
+  }
+
+  suppress(albumId: string): void {
+    this.setWithTTL(this.suppressKey(albumId), 24 * 60 * 60 * 1000);
+  }
+
+  markContact(albumId: string): void {
+    sessionStorage.setItem(this.contactKey(albumId), '1');
+  }
+
+  private isActive(): boolean {
+    return this.isVisible && this.isFocused;
+  }
+
+  private handleVisibility(): void {
+    this.isVisible = document.visibilityState === 'visible';
+    this.isFocused = document.hasFocus();
+  }
+
+  private isSuppressed(albumId: string): boolean {
+    return this.getWithTTL(this.suppressKey(albumId));
+  }
+
+  private hasContacted(albumId: string): boolean {
+    return !!sessionStorage.getItem(this.contactKey(albumId));
+  }
+
+  private suppressKey(id: string): string {
+    return `lkf_toast_suppress_${id}`;
+  }
+
+  private contactKey(id: string): string {
+    return `lkf_toast_contact_${id}`;
+  }
+
+  private setWithTTL(key: string, ttl: number): void {
+    const item = { value: '1', expiry: Date.now() + ttl };
+    localStorage.setItem(key, JSON.stringify(item));
+  }
+
+  private getWithTTL(key: string): boolean {
+    const raw = localStorage.getItem(key);
+    if (!raw) {
+      return false;
+    }
+    try {
+      const item = JSON.parse(raw);
+      if (Date.now() > item.expiry) {
+        localStorage.removeItem(key);
+        return false;
+      }
+      return true;
+    } catch {
+      localStorage.removeItem(key);
+      return false;
+    }
+  }
+}
+

--- a/src/app/services/toast.service.ts
+++ b/src/app/services/toast.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+export interface ToastConfig {
+  title: string;
+  message: string;
+  ctaLabel?: string;
+  albumId?: string;
+  albumTitle?: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class ToastService {
+  private toastSubject = new BehaviorSubject<ToastConfig | null>(null);
+  readonly toast$ = this.toastSubject.asObservable();
+
+  open(config: ToastConfig): void {
+    this.toastSubject.next(config);
+  }
+
+  close(): void {
+    this.toastSubject.next(null);
+  }
+}
+


### PR DESCRIPTION
## Summary
- add ToastService and AlbumEngagementService for timed album toast
- render EngagementToastComponent globally with Tailwind styling
- trigger toast on album pages after 30s of active viewing

## Testing
- `npm test` *(fails: sh: 1: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bcdb90d0c4833199df3e06035bea9f